### PR TITLE
Add multi-form section with Tally embed

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>FORMULARIOS FUNDOS</title>
     <link rel="stylesheet" href="css/styles.css">
+    <script src="https://tally.so/widgets/embed.js" defer></script>
 </head>
 <body>
     <header>

--- a/js/forms.js
+++ b/js/forms.js
@@ -3,9 +3,19 @@
 document.addEventListener('DOMContentLoaded', function() {
     const forms = [
         {
-            id: 'inspeccion',
-            title: 'INSPECCIÓN',
+            id: 'for1',
+            title: 'FOR1',
             embed: 'https://tally.so/embed/nrbv8o?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1'
+        },
+        {
+            id: 'for2',
+            title: 'FOR2',
+            embed: ''
+        },
+        {
+            id: 'for3',
+            title: 'FOR3',
+            embed: ''
         }
     ];
 
@@ -43,10 +53,8 @@ document.addEventListener('DOMContentLoaded', function() {
         iframe.setAttribute('marginwidth', '0');
         iframe.setAttribute('title', form.title);
         formContainer.appendChild(iframe);
-
-        const script = document.createElement('script');
-        script.src = 'https://tally.so/widgets/embed.js';
-        script.defer = true;
-        formContainer.appendChild(script);
+        if (window.Tally) {
+            Tally.loadEmbeds();
+        }
     }
 });


### PR DESCRIPTION
## Summary
- integrate the Tally embed script into the main page head
- support three forms (FOR1, FOR2, FOR3) and load Tally embeds

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d83c94aac83218c80a337188409ea